### PR TITLE
Fix: Register Page logo not visible (#1)

### DIFF
--- a/client/src/components/Register/Register.jsx
+++ b/client/src/components/Register/Register.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Logo from "../Logo";
+import Logo from "../Logo.jsx";
 import { Link, useNavigate } from "react-router";
 import { authService } from "../../service/auth.service";
 import { Label } from "@radix-ui/react-label";
@@ -37,7 +37,7 @@ function Register() {
             <div className="mx-auto w-full max-w-2xl rounded-2xl shadow-xl bg-black/40 backdrop-blur-lg p-8 space-y-6 border border-[#ae7aff]/20">
                 {/* Logo */}
                 <div className="flex m-0 justify-center">
-                    <Logo heightAndWidth={250} />
+                    <img src="/public/logo.png" alt="Logo" width={250} height={250} />
                 </div>
                 <h1 className="text-center text-3xl font-bold text-[#ae7aff] drop-shadow-md">
                     Create Your Account


### PR DESCRIPTION
## Fix: Register Page Logo not visible (#1)

### Problem
On the Register page, the StreamSphere logo was not loading, and the alt text was being shown instead.

### Solution
- Corrected the logo image path import
- Ensured the `src` points to the public/assets directory
- Verified logo loads properly in both dev and production builds

### Screenshots
(Add before/after screenshot if possible.)

Fixes #1 