### PR TITLE
Fix: Page refresh 404 not found

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+      {
+        "source": "/(.*)",
+        "destination": "/"
+      }
+    ]
+  }


### PR DESCRIPTION
## 📝 Summary
This Pr fixes a bug that after refreshing login or signup page, The page do not throw vercel 404 not found error.

Fixes #11

## 🛠️ Changes Made
- Added vercel.json - This file ensures client-side routing works by redirecting all paths to the main app entry point (/).